### PR TITLE
Quick Fix for Gnome 40

### DIFF
--- a/eye-extended@als.kz/metadata.json
+++ b/eye-extended@als.kz/metadata.json
@@ -4,7 +4,7 @@
   "settings-schema": "kz.als.eye-extended",
   "gettext-domain": "EyeExtended",
   "shell-version": [
-    "3.36.0", "3.38.0", "40"
+    "40"
   ], 
   "url": "https://github.com/alexeylovchikov/eye-extended-shell-extension", 
   "description": "Adds an eye to the indicator bar that follows your cursor \nYou can also display the mouse indicator, perhaps it will help you with the problem of displaying the mouse cursor in Skype"

--- a/eye-extended@als.kz/metadata.json
+++ b/eye-extended@als.kz/metadata.json
@@ -4,7 +4,7 @@
   "settings-schema": "kz.als.eye-extended",
   "gettext-domain": "EyeExtended",
   "shell-version": [
-    "3.36.0", "3.38.0"
+    "3.36.0", "3.38.0", "40"
   ], 
   "url": "https://github.com/alexeylovchikov/eye-extended-shell-extension", 
   "description": "Adds an eye to the indicator bar that follows your cursor \nYou can also display the mouse indicator, perhaps it will help you with the problem of displaying the mouse cursor in Skype"

--- a/eye-extended@als.kz/prefs.js
+++ b/eye-extended@als.kz/prefs.js
@@ -2,7 +2,7 @@ const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
-const Gdk = imports.gi.Gdk;
+//const Gdk = imports.gi.Gdk;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -53,7 +53,7 @@ const EyeExtendedSettings = new GObject.Class({
         let widget = null;
         let color = null;
         widget = new Gtk.ColorButton({halign: Gtk.Align.END});
-        widget.set_color(Gdk.Color.parse(this._settings.get_string(property_name)).pop());
+        //widget.set_color(Gdk.Color.parse(this._settings.get_string(property_name)).pop());
         widget.connect('color-set', (button) => {
             color = button.get_color().to_string();
             color = color[0] + color[1] + color[2] + color[5] + color[6] + color[9] + color[10];
@@ -232,7 +232,7 @@ const Notebook =  new GObject.Class({
 
 function buildPrefsWidget() {
     const widget = new Notebook();
-    widget.show_all();
+    //widget.show_all();
 
     return widget;
 }

--- a/eye-extended@als.kz/prefs.js
+++ b/eye-extended@als.kz/prefs.js
@@ -2,7 +2,7 @@ const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 const Gtk = imports.gi.Gtk;
 const Gio = imports.gi.Gio;
-//const Gdk = imports.gi.Gdk;
+const Gdk = imports.gi.Gdk;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -53,10 +53,13 @@ const EyeExtendedSettings = new GObject.Class({
         let widget = null;
         let color = null;
         widget = new Gtk.ColorButton({halign: Gtk.Align.END});
-        //widget.set_color(Gdk.Color.parse(this._settings.get_string(property_name)).pop());
+        let gdk_color = new Gdk.RGBA();
+        if (gdk_color.parse(this._settings.get_string(property_name))){
+            widget.set_rgba(gdk_color);
+        }
         widget.connect('color-set', (button) => {
-            color = button.get_color().to_string();
-            color = color[0] + color[1] + color[2] + color[5] + color[6] + color[9] + color[10];
+            color = button.get_rgba().to_string();
+            //color = color[0] + color[1] + color[2] + color[5] + color[6] + color[9] + color[10];
             this._settings.set_string(property_name, color);
         });
         if (next_row) {


### PR DESCRIPTION
Small and quick fix for gnome 40, this is my first contact with gnome extensions, sorry if I did something wrong.

1. Modified `Gdk.Color` to `Gdk.RGBA()`, and `button.get_color()` to `button.get_rgba()`.
2. [Removed `widget.show_all()`](https://gjs.guide/extensions/upgrading/gnome-shell-40.html#show-all-and-destroy).
3. Updated `shell_version` to `40` on metadata.

After testing on Gnome Shell 40.2 (Arch Linux), everything seems to be working correctly.